### PR TITLE
Preserve image aspect ratio in results

### DIFF
--- a/searx/static/themes/oscar/less/pointhi/results.less
+++ b/searx/static/themes/oscar/less/pointhi/results.less
@@ -33,12 +33,12 @@
 // image formating of results
 .result-images {
     float: left !important;
+    height: 138px;
 }
 
 .img-thumbnail {
     margin: 5px;
     max-height: 128px;
-    min-height: 128px;
 }
 
 // video formating of results


### PR DESCRIPTION
Noticed that images are often distorted in the results due to a hard minimum height.  This keeps the 4-per-row image results consistent in row height without distorting wider images.